### PR TITLE
Added allocations dict attr to Memory

### DIFF
--- a/memory.py
+++ b/memory.py
@@ -106,6 +106,14 @@ class MemoryHandler():
 
 
 class Memory():
+    default_val_map = {
+        INT: 0,
+        FLOAT: 0.0,
+        BOOL: False,
+        STRING: '',
+        POINTER: None
+    }
+
     def __init__(self, start, max_size):
         self.start = start
         self.sections = {
@@ -115,6 +123,12 @@ class Memory():
             STRING: [],
             POINTER: []
         }
+        self.allocations = {
+            INT: 0,
+            FLOAT: 0,
+            BOOL: 0,
+            STRING: 0
+        }
         self.max_size = max_size
 
     def reserveAddress(self, dtype):
@@ -122,19 +136,12 @@ class Memory():
         Increase the list size of the given type (INT, FLOAT, BOOL, STRING).
         returns the local address of the reserved space
         '''
-        if len(self.sections[dtype]) == self.max_size:
+        if self.allocations[dtype] == self.max_size:
             raise Exception(
                 f'ERROR: Cannot allocate any more values of type "{stringifyToken(dtype)}", limit is {self.max_size}')
 
-        default_val_map = {
-            INT: 0,
-            FLOAT: 0.0,
-            BOOL: False,
-            STRING: '',
-            POINTER: 0
-        }
-
-        self.sections[dtype].append(default_val_map[dtype])
+        self.sections[dtype].append(self.default_val_map[dtype])
+        self.allocations[dtype] += 1
         return len(self.sections[dtype]) - 1
 
     def updateAddress(self, address, dtype=None, value=None):

--- a/virtual_machine.py
+++ b/virtual_machine.py
@@ -169,8 +169,10 @@ def run(obj_file):
             # Push function's memory ctx to stack
             memCtxWrapper.push(memHandler)
             func_mem = memCtxWrapper.top()
-            func_mem.flush(LOCAL)
-            func_mem.flush(TEMPORAL)
+            # Flush allocated values from memory, but keep count of how many have been allocated
+            for context in [LOCAL, TEMPORAL]:
+                func_mem.flush(context)
+                func_mem.contexts[context].allocations = memHandler.contexts[context].allocations
 
             if l == 'self':  # Recursive class call
                 class_var = ctx.getAttributes(ctx.getClassContext())
@@ -210,8 +212,10 @@ def run(obj_file):
             if not method_call:
                 memCtxWrapper.push(memHandler)
                 func_mem = memCtxWrapper.top()
-                func_mem.flush(LOCAL)
-                func_mem.flush(TEMPORAL)
+                # Flush allocated values from memory, but keep count of how many have been allocated
+                for context in [LOCAL, TEMPORAL]:
+                    func_mem.flush(context)
+                    func_mem.contexts[context].allocations = memHandler.contexts[context].allocations
             else:
                 func_mem = memCtxWrapper.top()
 


### PR DESCRIPTION
This attribute is now used to check how many allocations there has been for a given data type. This is used greatly in the VM when switching contexts